### PR TITLE
Add Capture One installer package

### DIFF
--- a/overlays/20-capture-one.nix
+++ b/overlays/20-capture-one.nix
@@ -1,0 +1,34 @@
+self: super:
+with super; {
+  capture-one = stdenvNoCC.mkDerivation rec {
+    pname = "capture-one";
+    version = "16.6.5.17";
+
+    src = fetchurl {
+      url = "https://downloads.captureone.pro/d/mac/39c0c6f987ddd1d187d6fb3cb3680b01673344cc/CaptureOne.Mac.16.6.5.17.dmg";
+      sha256 = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="; # TODO: replace with actual hash
+    };
+
+    nativeBuildInputs = [ undmg ];
+
+    unpackPhase = ''
+      undmg "$src"
+    '';
+
+    installPhase = ''
+      APP_NAME="Capture One.app"
+      echo "Installing $APP_NAME into /Applications"
+      mkdir -p /Applications
+      cp -R "$APP_NAME" /Applications/
+      rm -rf "$APP_NAME"
+      mkdir -p $out
+    '';
+
+    meta = with lib; {
+      description = "Capture One photo editing software";
+      homepage = "https://www.captureone.com/";
+      license = licenses.unfree;
+      platforms = platforms.darwin;
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- add `capture-one` package overlay using Capture One 16.6.5.17 DMG

## Testing
- `pre-commit run --files overlays/20-capture-one.nix` *(fails: Executable `nix` not found)*
- `nix --extra-experimental-features nix-command --extra-experimental-features flakes flake check` *(fails: command not found: nix)*

------
https://chatgpt.com/codex/tasks/task_b_68b318ba7a98832291aa9e5d241d699b